### PR TITLE
Ignore ordering in two unit tests

### DIFF
--- a/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
+++ b/core/server/worker/src/test/java/alluxio/worker/block/meta/DefaultStorageTierTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Unit tests for {@link DefaultStorageTier}.
@@ -140,8 +142,12 @@ public class DefaultStorageTierTest {
   public void getStorageDirs() {
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(2, dirs.size());
-    Assert.assertEquals(mTestBlockDirPath1, dirs.get(0).getDirPath());
-    Assert.assertEquals(mTestBlockDirPath2, dirs.get(1).getDirPath());
+    Set<String> actualDirPaths = new HashSet<>();
+    dirs.forEach((dir) -> actualDirPaths.add(dir.getDirPath()));
+    Set<String> expectedDirPaths = new HashSet<>();
+    expectedDirPaths.add(mTestBlockDirPath1);
+    expectedDirPaths.add(mTestBlockDirPath2);
+    Assert.assertEquals(expectedDirPaths, actualDirPaths);
   }
 
   @Test
@@ -166,6 +172,8 @@ public class DefaultStorageTierTest {
     mTier = DefaultStorageTier.newStorageTier(Constants.MEDIUM_MEM, false);
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(2, dirs.size());
-    Assert.assertEquals(mTestBlockDirPath1, dirs.get(0).getDirPath());
+    Set<String> actualDirPaths = new HashSet<>();
+    dirs.forEach((dir) -> actualDirPaths.add(dir.getDirPath()));
+    Assert.assertTrue(actualDirPaths.contains(mTestBlockDirPath1));
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request?

This pull request utilizes `HashSet` to ignore the ordering of the directory paths that are generated through `HashMap` iteration by the `StorageTier.getStorageDirs` method. This pull request modifies the tests `alluxio.worker.block.meta.DefaultStorageTierTest.getStorageDirs` and `alluxio.worker.block.meta.DefaultStorageTierTest.tolerantMisconfigurationInStorageDir` and helps them account for this non-deterministic behavior.

### Why are the changes needed?

As stated on the Javadoc for `HashMap`, "This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time." Hence, these changes help ensure that these tests will still pass in the event that the iteration order of `HashMap` changes. This issue was detected by the tool [NonDex](https://github.com/TestingResearchIllinois/NonDex).

### Does this PR introduce any user facing changes?

No
